### PR TITLE
fix value assigment for string options

### DIFF
--- a/src/serviceapp/exteplayer3.cpp
+++ b/src/serviceapp/exteplayer3.cpp
@@ -107,6 +107,7 @@ int ExtEplayer3Options::update(const std::string &key, const std::string &val)
 		}
 		else if (entry.getType() == "string")
 		{
+        	entry.setValue(val);
 		}
 	}
 	else


### PR DESCRIPTION
example https://aqq.url#sapp_ffmpeg_option=reconnect=1 Before:
ExtEplayer3::ExtEplayer3 initializing with options: ...
ffmpeg_option  = not set 

After:
ExtEplayer3::ExtEplayer3 initializing with options: ...
ffmpeg_option  = reconnect=1