### PR TITLE
fix building list of args for execution

### DIFF
--- a/src/serviceapp/exteplayer3.cpp
+++ b/src/serviceapp/exteplayer3.cpp
@@ -192,11 +192,8 @@ std::vector<std::string> ExtEplayer3::buildCommand()
 		}
 		if (i->second.getType() == "int" || i->second.getType() == "string")
 		{
-			std::stringstream ss;
-			ss << i->second.getAppArg();
-			ss << " ";
-			ss << i->second.getValue();
-			args.push_back(ss.str());
+            args.push_back(i->second.getAppArg()); //add arg name to list of args
+			args.push_back(i->second.getValue());  //add value to list of args
 		}
 	}
 	return args;


### PR DESCRIPTION
Before:
arg name and value were 'joined' together and pushed to the list of args as a single arg E.g. "-0 0" causing exteplayer3 to incorrectly interpret them

After:
arg name and value are pushed to the args list separatedly E.g. "-0" "0" enabling exteplayer3 to work properly