### PR TITLE
New "sapp_args" argument

### DIFF
--- a/src/serviceapp/exteplayer3.cpp
+++ b/src/serviceapp/exteplayer3.cpp
@@ -29,6 +29,7 @@ const std::string  EXT3_ARG_LCASE_B                = "b";
 const std::string  EXT3_ARG_5                      = "5";
 const std::string  EXT3_ARG_6                      = "6";
 const std::string  EXT3_ARG_7                      = "7";
+const std::string  EXT3_ARGS_LIST                  = "args"; // cmdline like list of exteplayer3 arguments in a form "-arg1=value1-arg2=value2"
 
 SettingMap &ExtEplayer3Options::GetSettingMap()
 {
@@ -63,6 +64,7 @@ ExtEplayer3Options::ExtEplayer3Options()
 	settingMap[EXT3_ARG_5]                      = SettingEntry ("-5", "string");
 	settingMap[EXT3_ARG_6]                      = SettingEntry ("-6", "string");
 	settingMap[EXT3_ARG_7]                      = SettingEntry ("-7", "string");
+	settingMap[EXT3_ARGS_LIST]                  = SettingEntry ("al", "argslist");
 }
 
 int ExtEplayer3Options::update(const std::string &key, const std::string &val)
@@ -116,6 +118,10 @@ int ExtEplayer3Options::update(const std::string &key, const std::string &val)
 		else if (entry.getType() == "string")
 		{
         	entry.setValue(val);
+		}
+		else if (entry.getType() == "argslist")
+		{
+                     entry.setValue(val);
 		}
 	}
 	else
@@ -203,6 +209,38 @@ std::vector<std::string> ExtEplayer3::buildCommand()
             args.push_back(i->second.getAppArg()); //add arg name to list of args
 			args.push_back(i->second.getValue());  //add value to list of args
 		}
+		if (i->second.getType() == "argslist")
+                {
+                        std::stringstream ss(i->second.getValue());
+                        std::string item;
+
+                        while (std::getline(ss, item, '-'))
+                        {
+                                if (!item.empty())
+                                {
+                                        if (item.find("exteplayer3") != std::string::npos)
+                                        {
+                                                args[0] = item;
+                                        }
+                                        else
+                                        {
+                                                // split arg=value
+                                                size_t eq = item.find('=');
+                                                if (eq != std::string::npos)
+                                                {
+                                                        std::string key = item.substr(0, eq);
+                                                        std::string value = item.substr(eq + 1);
+                                                        args.push_back("-" + key);
+                                                        args.push_back(value);
+                                                }
+                                                else
+                                                {
+                                                        args.push_back(item);
+                                                }
+                                        }
+                                }
+                        }
+                }
 	}
 	return args;
 }


### PR DESCRIPTION
This change does not affect any already existing functions or functionalities.

It implements commadline like arguments list to allow providing any set of options to exteplayer3 and ffmpeg.
Unblocks usage of multiple ffmpeg switches in an URL parameters which doesn't work with the "sapp_ffmpeg_option" option

Example usage:
"sapp_args=-f=live_start_offset_seconds=60-f=rw_timeout=2000000-f=reconnect=1-f=http_multiple=0"
